### PR TITLE
Add typo3/cms:extension-key to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,10 @@
     "replace": {
         "branch_cache": "self.version",
         "typo3-ter/branch-cache": "self.version"
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "branch_cache"
+        }
     }
 }


### PR DESCRIPTION
Add typo3/cms:extension-key to composer.json so composer will not throw a deprecation warning